### PR TITLE
增加配置项 `eventBufferCapacity` 支持自定义事件缓冲区容量

### DIFF
--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/QGBotFileConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/QGBotFileConfiguration.kt
@@ -228,7 +228,22 @@ public data class QGBotFileConfiguration(
          */
         @SerialName("cache") public val cacheConfig: CacheConfig? = DEFAULT.cacheConfig,
 
-        ) {
+        /**
+         * 事件缓冲区容量。
+         *
+         * ```json
+         * {
+         *   "config": {
+         *     "eventBufferCapacity": 64
+         *   }
+         * }
+         * ```
+         *
+         * @see BotConfiguration.eventBufferCapacity
+         */
+        public val eventBufferCapacity: Int? = null
+
+    ) {
         public companion object {
             internal const val SERVER_URL_SANDBOX_VALUE: String = "SANDBOX"
             private val DEFAULT = QGBotComponentConfiguration()
@@ -283,6 +298,10 @@ public data class QGBotFileConfiguration(
                     configuration.apiHttpRequestTimeoutMillis = timeout.apiHttpRequestTimeoutMillis
                     configuration.apiHttpConnectTimeoutMillis = timeout.apiHttpConnectTimeoutMillis
                     configuration.apiHttpSocketTimeoutMillis = timeout.apiHttpSocketTimeoutMillis
+                }
+
+                eventBufferCapacity?.also {
+                    configuration.eventBufferCapacity = it
                 }
 
 

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/BotConfiguration.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/BotConfiguration.kt
@@ -159,7 +159,6 @@ public interface BotConfiguration {
      */
     public val wsClientEngineFactory: HttpClientEngineFactory<*>?
 
-
     /**
      * 用于API请求结果反序列化的 [Json].
      *
@@ -174,6 +173,27 @@ public interface BotConfiguration {
      */
     public val apiDecoder: Json
 
+    /**
+     * BOT内事件冲区的容量。
+     *
+     * 缓冲区中堆积的事件如果已满则后续推送的事件会挂起等待缓冲区内元素的消费。
+     *
+     * @see DEFAULT_EVENT_BUFFER_CAPACITY
+     *
+     */
+    public val eventBufferCapacity: Int
+
+
+    public companion object {
+
+        /**
+         * 事件缓冲区的默认容量: `64`
+         *
+         * _此默认值没什么特殊含义，一拍脑袋想的。_
+         *
+         */
+        public const val DEFAULT_EVENT_BUFFER_CAPACITY: Int = 64
+    }
 }
 
 

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/ConfigurableBotConfiguration.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/ConfigurableBotConfiguration.kt
@@ -22,6 +22,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.http.*
 import kotlinx.serialization.json.Json
+import love.forte.simbot.qguild.BotConfiguration.Companion.DEFAULT_EVENT_BUFFER_CAPACITY
 import love.forte.simbot.qguild.event.EventIntents
 import love.forte.simbot.qguild.event.Intents
 import love.forte.simbot.qguild.event.Shard
@@ -175,6 +176,17 @@ public class ConfigurableBotConfiguration : BotConfiguration {
      */
     override var apiDecoder: Json = defaultJson
 
+    /**
+     * BOT内接收到事件后推送到的缓冲区的容量。
+     *
+     * 缓冲区中堆积的事件如果已满则后续推送的事件会挂起等待缓冲区内元素的消费。
+     *
+     * 默认为 [`64`][DEFAULT_EVENT_BUFFER_CAPACITY]。
+     *
+     * @see DEFAULT_EVENT_BUFFER_CAPACITY
+     *
+     */
+    override var eventBufferCapacity: Int = DEFAULT_EVENT_BUFFER_CAPACITY
 
     public companion object {
         private val defaultJson = Json {
@@ -199,6 +211,7 @@ public class ConfigurableBotConfiguration : BotConfiguration {
         wsClientEngine = wsClientEngine,
         wsClientEngineFactory = wsClientEngineFactory,
         apiDecoder = apiDecoder,
+        eventBufferCapacity = eventBufferCapacity,
     )
 }
 
@@ -217,4 +230,5 @@ private class BotConfigurationImpl(
     override val wsClientEngine: HttpClientEngine?,
     override val wsClientEngineFactory: HttpClientEngineFactory<*>?,
     override val apiDecoder: Json,
+    override val eventBufferCapacity: Int,
 ) : BotConfiguration

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/internal/BotImpl.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/internal/BotImpl.kt
@@ -495,8 +495,9 @@ internal class BotImpl(
         val session: DefaultClientWebSocketSession
     ) : Stage() {
         override suspend fun invoke(loop: StageLoop<Stage>) {
-            // TODO capacity configurable?
-            val sharedFlow = MutableSharedFlow<EventData>(extraBufferCapacity = 16)
+            val eventBufferCapacity = configuration.eventBufferCapacity
+            logger.debug("Bot event buffer capacity: {}", eventBufferCapacity)
+            val sharedFlow = MutableSharedFlow<EventData>(extraBufferCapacity = eventBufferCapacity)
             launchEventProcessJob(sharedFlow)
 
             val client = ClientImpl(


### PR DESCRIPTION
stdlib中：

```kotlin
BotFactory.create("", "", "") {
    eventBufferCapacity = 64
}
```

配置文件中：

```json
{
  "config": { "eventBufferCapacity": 64 }
}
```