### PR TITLE
QQGuildApi 进行请求时 的client 不再强制需要安装 ContentNegotiation

### DIFF
--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -33,6 +33,6 @@ jobs:
             allTests
             --info 
             --warning-mode all
-            --build-cache
-            -Porg.gradle.jvmargs="-Xmx4g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
-            -Porg.gradle.daemon=false
+#            --build-cache
+#            -Porg.gradle.daemon=false
+#            -Porg.gradle.jvmargs="-Xmx4g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 
 org.gradle.daemon=false
+org.gradle.parallel=false

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/forum/QGForum.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/forum/QGForum.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.forum
+
+import love.forte.simbot.definition.BotContainer
+import love.forte.simbot.definition.GuildInfoContainer
+import love.forte.simbot.qguild.model.ChannelType
+import love.forte.simbot.qguild.model.Channel as QGSourceChannel
+
+/**
+ * 一个帖子类型的频道。
+ *
+ * [QGForum] 基于 [子频道][QGSourceChannel] 类型，
+ * 提供有关帖子的相关功能，包括查询帖子、发帖、删贴等。
+ *
+ * [QGForum] 内包含一个类型为 [ChannelType.FORUM] 的频道信息。
+ *
+ * 需要注意的是，[QGForum] 只会在构建时检测频道类型，当一个 [QGForum] 被持有，
+ * 而在此期间此频道类型发生了改变，那么后续继续调用API则可能会引发 [IllegalStateException] 异常。
+ *
+ * @author ForteScarlet
+ */
+public interface QGForum : BotContainer, GuildInfoContainer {
+
+    /**
+     * 表示此帖子频道的源频道。
+     */
+    public val source: QGSourceChannel
+
+    // TODO 查、发、删
+
+}

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/util/ComponentBotRequestUtil.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/util/ComponentBotRequestUtil.kt
@@ -23,6 +23,8 @@ import love.forte.simbot.component.qguild.QGBot
 import love.forte.simbot.qguild.api.QQGuildApi
 import love.forte.simbot.qguild.request
 import love.forte.simbot.qguild.requestBy
+import love.forte.simbot.qguild.requestRaw
+import love.forte.simbot.qguild.requestRawBy
 
 /**
  * 直接通过bot进行请求。
@@ -42,4 +44,24 @@ public suspend inline fun <R> QQGuildApi<R>.requestBy(bot: QGBot): R {
 @JvmSynthetic
 public suspend inline fun <R> QGBot.request(api: QQGuildApi<R>): R {
     return source.request(api)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@JvmSynthetic
+public suspend inline fun QQGuildApi<*>.requestRawBy(bot: QGBot): String {
+    return requestRawBy(bot.source)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@JvmSynthetic
+public suspend inline fun QGBot.requestRaw(api: QQGuildApi<*>): String {
+    return source.requestRaw(api)
 }

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/util/QGBotRequestUtil.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/util/QGBotRequestUtil.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022-2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@file:JvmName("QGBotRequestUtil")
+
+package love.forte.simbot.component.qguild.util
+
+import kotlinx.coroutines.future.future
+import love.forte.simbot.Api4J
+import love.forte.simbot.component.qguild.QGBot
+import love.forte.simbot.qguild.api.QQGuildApi
+import love.forte.simbot.qguild.request
+import love.forte.simbot.qguild.requestBy
+import love.forte.simbot.qguild.requestRaw
+import love.forte.simbot.qguild.requestRawBy
+import love.forte.simbot.utils.runInNoScopeBlocking
+import java.util.concurrent.CompletableFuture
+
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun <R> QQGuildApi<R>.requestBlockingBy(bot: QGBot): R = runInNoScopeBlocking {
+    requestBy(bot.source)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun <R> QQGuildApi<R>.requestAsyncBy(bot: QGBot): CompletableFuture<out R> = bot.source.future {
+    requestBy(bot.source)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun <R> QGBot.requestBlocking(api: QQGuildApi<R>): R = runInNoScopeBlocking {
+    source.request(api)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun <R> QGBot.requestAsync(api: QQGuildApi<R>): CompletableFuture<out R> = source.future {
+    source.request(api)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun QGBot.requestRawBlocking(api: QQGuildApi<*>): String = runInNoScopeBlocking {
+    source.requestRaw(api)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun QGBot.requestRawAsync(api: QQGuildApi<*>): CompletableFuture<out String> = source.future {
+    source.requestRaw(api)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun QQGuildApi<*>.requestRawBlockingBy(bot: QGBot): String = runInNoScopeBlocking {
+    requestRawBy(bot.source)
+}
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun QQGuildApi<*>.requestRawAsyncBy(bot: QGBot): CompletableFuture<out String> = bot.source.future {
+    requestRawBy(bot.source)
+}

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/BotRequestor.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/BotRequestor.kt
@@ -19,6 +19,7 @@ package love.forte.simbot.qguild
 
 import love.forte.simbot.qguild.api.QQGuildApi
 import love.forte.simbot.qguild.api.request
+import love.forte.simbot.qguild.api.requestRaw
 import love.forte.simbot.qguild.internal.BotImpl
 import kotlin.jvm.JvmSynthetic
 
@@ -39,6 +40,22 @@ public suspend fun <R> QQGuildApi<R>.requestBy(bot: Bot): R {
     )
 }
 
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@JvmSynthetic
+public suspend fun <R> QQGuildApi<R>.requestRawBy(bot: Bot): String {
+    val botToken = if (bot is BotImpl) bot.botToken else "Bot ${bot.ticket.appId}.${bot.ticket.token}"
+    return requestRaw(
+        client = bot.apiClient,
+        server = bot.apiServer,
+        token = botToken,
+    )
+}
+
 /**
  * 直接通过bot进行请求。
  *
@@ -46,6 +63,15 @@ public suspend fun <R> QQGuildApi<R>.requestBy(bot: Bot): R {
  */
 @JvmSynthetic
 public suspend fun <R> Bot.request(api: QQGuildApi<R>): R = api.requestBy(this)
+
+
+/**
+ * 直接通过bot进行请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@JvmSynthetic
+public suspend fun <R> Bot.requestRaw(api: QQGuildApi<R>): String = api.requestRawBy(this)
 
 
 

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/internal/BotImpl.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/internal/BotImpl.kt
@@ -132,7 +132,7 @@ internal class BotImpl(
 
     private fun HttpClientConfig<*>.configApiHttpClient() {
         install(ContentNegotiation) {
-            json()
+            json(configuration.apiDecoder)
         }
 
         val apiHttpRequestTimeoutMillis = configuration.apiHttpRequestTimeoutMillis

--- a/simbot-component-qq-guild-stdlib/src/jvmMain/kotlin/love/forte/simbot/qguild/BotRequestorJvm.kt
+++ b/simbot-component-qq-guild-stdlib/src/jvmMain/kotlin/love/forte/simbot/qguild/BotRequestorJvm.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture
 
 /**
  * @see requestBlocking
- * @suppress use [requestBlocking]
+ * @suppress use [requestBlocking] or [requestAsync]
  * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
  */
 @Api4J
@@ -51,4 +51,24 @@ public fun <R> requestBlocking(bot: Bot, api: QQGuildApi<R>): R = runInNoScopeBl
 @Api4J
 public fun <R> requestAsync(bot: Bot, api: QQGuildApi<R>): CompletableFuture<out R> = bot.future {
     api.requestBy(bot)
+}
+
+/**
+ * 直接通过bot进行阻塞地请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun requestRawBlocking(bot: Bot, api: QQGuildApi<*>): String = runInNoScopeBlocking {
+    api.requestRawBy(bot)
+}
+
+/**
+ * 直接通过bot进行异步地请求。
+ *
+ * @throws love.forte.simbot.qguild.QQGuildApiException 如果返回状态码不在 200..300之间。
+ */
+@Api4J
+public fun requestRawAsync(bot: Bot, api: QQGuildApi<*>): CompletableFuture<out String> = bot.future {
+    api.requestRawBy(bot)
 }


### PR DESCRIPTION
QQGuildApi的请求如果存在 `body` 现在不在要求使用的 HttpClient 需要安装 `ContentNegotiation` 了（不过内部使用的各种默认 `HttpClient` 依旧会安装，并且仍旧建议安装 `ContentNegotiation`）

当使用未安装 `ContentNegotiation` 的 `HttpClient` 时，内部会使用一些类似于此插件功能的方式来实现json处理。