### PR TITLE
Bot 配置文件中 `ticket` 支持使用环境变量

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -20,7 +20,7 @@ import love.forte.gradle.common.core.project.Version
 import love.forte.gradle.common.core.project.minus
 import love.forte.gradle.common.core.project.version as v
 
-val simbotVersion = v(3, 1, 0)
+val simbotVersion = v(3, 2, 0)
 //- v("RC", 3)
 
 fun simbot(name: String, version: String = simbotVersion.toString()): String = "love.forte.simbot:simbot-$name:$version"
@@ -62,7 +62,7 @@ object P {
             0, 0
         )
 
-        private val alphaSuffix = v("alpha", 9)
+        private val alphaSuffix = v("alpha", 10)
 
         override val version = baseVersion - alphaSuffix
         val snapshotVersion = baseVersion - (alphaSuffix - Version.SNAPSHOT)

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/BaseQQGuildBotManager.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/BaseQQGuildBotManager.kt
@@ -68,10 +68,11 @@ public abstract class BaseQQGuildBotManager : BotManager<QGBot>() {
             )
             throw ComponentMismatchException("[$component] != [$currentComponent]")
         }
+
         val configuration = verifyInfo.decode(serializer)
 
         // no config
-        val (appId, secret, token) = configuration.ticket
+        val (appId, secret, token) = configuration.ticket.toTicket()
         return register(appId, secret, token, configuration::includeConfig)
     }
 

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QQGuildComponent.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QQGuildComponent.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import love.forte.simbot.*
+import love.forte.simbot.component.qguild.config.QGBotFileConfiguration
 import love.forte.simbot.component.qguild.message.*
 import love.forte.simbot.message.At
 import love.forte.simbot.message.Message
@@ -126,6 +127,8 @@ public class QQGuildComponent : Component {
             polymorphic(Message.Element::class) {
                 subclass0()
             }
+
+            include(QGBotFileConfiguration.serializersModule)
         }
         
         

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/QGBotFileConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/QGBotFileConfiguration.kt
@@ -20,6 +20,7 @@ package love.forte.simbot.component.qguild.config
 import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
 import love.forte.simbot.qguild.Bot
 import love.forte.simbot.qguild.BotConfiguration
 import love.forte.simbot.qguild.QQGuild
@@ -62,7 +63,7 @@ public data class QGBotFileConfiguration(
     /**
      * bot相关的票据信息，必填。
      */
-    val ticket: Ticket,
+    val ticket: TicketConfiguration,
 
     /**
      * 其他配置信息。
@@ -75,6 +76,7 @@ public data class QGBotFileConfiguration(
      * @see Bot.Ticket
      */
     @Serializable
+    @UsedOnlyForConfigSerialization
     public data class Ticket(
         /**
          * 用于识别一个机器人的 id
@@ -307,5 +309,12 @@ public data class QGBotFileConfiguration(
 
             }
         }
+    }
+
+    public companion object {
+        internal val serializersModule = SerializersModule {
+            include(TicketConfiguration.serializersModule)
+        }
+
     }
 }

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+
+
+/**
+ *
+ * 用于配置 [QGBotFileConfiguration.Ticket] 信息的配置属性，
+ * 提供多种可选的配置方案。
+ *
+ * ```json
+ * {
+ *   "ticket": {
+ *     "type": "...",
+ *     "prop1": "v1"
+ *   }
+ * }
+ * ```
+ *
+ * @author ForteScarlet
+ */
+@UsedOnlyForConfigSerialization
+@Serializable
+public sealed class TicketConfiguration {
+
+    /**
+     * 得到 [QGBotFileConfiguration.Ticket] 结果
+     */
+    public abstract fun toTicket(): QGBotFileConfiguration.Ticket
+
+
+    /**
+     * 与 [QGBotFileConfiguration.Ticket] 一致的配置类型，
+     * 也是 [TicketConfiguration] 的默认方案。
+     *
+     * ```json
+     * {
+     *   "ticket": {
+     *     "type": "simple",
+     *     "appId": "appId-value",
+     *     "secret": "secret-value",
+     *     "token": "token-value"
+     *   }
+     * }
+     * ```
+     *
+     * 或
+     *
+     * ```json
+     *      * {
+     *      *   "ticket": {
+     *      *     "appId": "appId-value",
+     *      *     "secret": "secret-value",
+     *      *     "token": "token-value"
+     *      *   }
+     *      * }
+     *      * ```
+     *
+     */
+    @Serializable
+    @SerialName(Simple.TYPE)
+    public data class Simple(
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val appId: String,
+
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val secret: String,
+
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val token: String
+    ) : TicketConfiguration() {
+
+        override fun toTicket(): QGBotFileConfiguration.Ticket =
+            QGBotFileConfiguration.Ticket(appId, secret, token)
+
+        public companion object {
+            public const val TYPE: String = "simple"
+        }
+    }
+
+    // TODO
+
+    public companion object {
+        internal val serializersModule = SerializersModule {
+            polymorphicDefaultDeserializer(TicketConfiguration::class) { Simple.serializer() }
+        }
+    }
+}

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
@@ -182,7 +182,7 @@ public sealed class TicketConfiguration {
         val token: String,
 
         /**
-         * 直接使用
+         * 是否允许在无法获取到对应的 JVM 参数或环境变量时，直接使用原始输入值。
          */
         val plain: Boolean = false,
     ) : TicketConfiguration() {
@@ -203,12 +203,10 @@ public sealed class TicketConfiguration {
                 return prop.substringAfter(PLAIN_PREFIX, missingDelimiterValue = "")
             }
 
-            val value = System.getProperty(prop) ?: System.getenv(prop)
-            if (value != null) return value
-
-            if (plain) return prop
-
-            throw IllegalStateException("Cannot find property '$prop' for ticket '$key' in JVM or environment variables.")
+            return System.getProperty(prop)
+                ?: System.getenv(prop)
+                ?: if (plain) return prop
+                else throw IllegalStateException("Cannot find property '$prop' for ticket '$key' in JVM or environment variables.")
         }
 
         public companion object {

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
@@ -66,14 +66,16 @@ public sealed class TicketConfiguration {
      * 或
      *
      * ```json
-     *      * {
-     *      *   "ticket": {
-     *      *     "appId": "appId-value",
-     *      *     "secret": "secret-value",
-     *      *     "token": "token-value"
-     *      *   }
-     *      * }
-     *      * ```
+     * {
+     *   "ticket": {
+     *     "appId": "appId-value",
+     *     "secret": "secret-value",
+     *     "token": "token-value"
+     *   }
+     * }
+     * ```
+     *
+     * > Note: 默认 `type` 的支持需要 simbot-core 3.2.0+
      *
      */
     @Serializable
@@ -103,7 +105,118 @@ public sealed class TicketConfiguration {
         }
     }
 
-    // TODO
+    /**
+     * 使用JVM参数或环境变量来读取 [QGBotFileConfiguration.Ticket] 中对应的配置类型。
+     *
+     * ```json
+     * {
+     *   "ticket": {
+     *     "type": "env",
+     *     "appId": "APP_ID",
+     *     "secret": "SECRET",
+     *     "token": "TOKEN",
+     *     "plain": false
+     *   }
+     * }
+     * ```
+     *
+     * [Env] 会首先尝试获取 JVM 参数，即运行时的 `-Dxxx=xxx` （也就是 [System.getProperty]），
+     * 当不存在时会尝试通过环境变量获取（即 [System.getenv]）。
+     *
+     * ## 原始输入
+     *
+     * 当 [plain] 为 `true` 时（默认为 `false`），如果某属性通过上述流程无法获取到值，则会尝试直接使用原始输入值。
+     *
+     * 例如：
+     * ```json
+     * {
+     *   "ticket": {
+     *     "type": "env",
+     *     "appId": "aaa",
+     *     "secret": "MY_SECRET",
+     *     "token": "MY_TOKEN",
+     *     "plain": true
+     *    }
+     *  }
+     *  ```
+     *
+     * 示例中的 `appId` 并没有找到名为 `aaa` 的 JVM 参数或环境变量，因此它会直接使用 `aaa` 作为 appId。
+     * 而如果 [plain] 为 `false`，则会直接抛出 [IllegalStateException] 异常。
+     *
+     *
+     * 当一个属性以 `PLAIN:` （区分大小写） 为前缀，则会直接使用原始输入值，不会尝试从环境变量中获取。
+     *
+     * 例如：
+     * ```json
+     * {
+     *   "ticket": {
+     *     "type": "env",
+     *     "appId": "PLAIN:aaa",
+     *     "secret": "MY_SECRET",
+     *     "token": "MY_TOKEN",
+     *     "plain": false
+     *   }
+     * }
+     * ```
+     *
+     * 示例中 `appId` 会直接使用 `aaa` 作为 appId，而不会尝试从 JVM 参数或环境变量中获取。
+     *
+     *
+     */
+    @Serializable
+    @SerialName(Simple.TYPE)
+    public data class Env(
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val appId: String,
+
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val secret: String,
+
+        /**
+         * @see QGBotFileConfiguration.Ticket
+         */
+        val token: String,
+
+        /**
+         * 直接使用
+         */
+        val plain: Boolean = false,
+    ) : TicketConfiguration() {
+
+        /**
+         * @throws IllegalStateException 当 [plain] 为 `false` 时，无法获取到对应的 JVM 参数或环境变量时。
+         */
+        override fun toTicket(): QGBotFileConfiguration.Ticket {
+            val appIdValue = prop("appId", appId)
+            val secretValue = prop("secret", secret)
+            val tokenValue = prop("token", token)
+
+            return QGBotFileConfiguration.Ticket(appIdValue, secretValue, tokenValue)
+        }
+
+        private fun prop(key: String, prop: String): String {
+            if (prop.startsWith(PLAIN_PREFIX)) {
+                return prop.substringAfter(PLAIN_PREFIX, missingDelimiterValue = "")
+            }
+
+            val value = System.getProperty(prop) ?: System.getenv(prop)
+            if (value != null) return value
+
+            if (plain) return prop
+
+            throw IllegalStateException("Cannot find property '$prop' for ticket '$key' in JVM or environment variables.")
+        }
+
+        public companion object {
+            public const val TYPE: String = "env"
+            private const val PLAIN_PREFIX = "PLAIN:"
+        }
+    }
+
 
     public companion object {
         internal val serializersModule = SerializersModule {

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/config/TicketConfiguration.kt
@@ -55,7 +55,7 @@ public sealed class TicketConfiguration {
      * ```json
      * {
      *   "ticket": {
-     *     "type": "simple",
+     *     "type": "plain",
      *     "appId": "appId-value",
      *     "secret": "secret-value",
      *     "token": "token-value"
@@ -79,8 +79,8 @@ public sealed class TicketConfiguration {
      *
      */
     @Serializable
-    @SerialName(Simple.TYPE)
-    public data class Simple(
+    @SerialName(Plain.TYPE)
+    public data class Plain(
         /**
          * @see QGBotFileConfiguration.Ticket
          */
@@ -101,7 +101,7 @@ public sealed class TicketConfiguration {
             QGBotFileConfiguration.Ticket(appId, secret, token)
 
         public companion object {
-            public const val TYPE: String = "simple"
+            public const val TYPE: String = "plain"
         }
     }
 
@@ -164,7 +164,7 @@ public sealed class TicketConfiguration {
      *
      */
     @Serializable
-    @SerialName(Simple.TYPE)
+    @SerialName(Env.TYPE)
     public data class Env(
         /**
          * @see QGBotFileConfiguration.Ticket
@@ -218,7 +218,7 @@ public sealed class TicketConfiguration {
 
     public companion object {
         internal val serializersModule = SerializersModule {
-            polymorphicDefaultDeserializer(TicketConfiguration::class) { Simple.serializer() }
+            polymorphicDefaultDeserializer(TicketConfiguration::class) { Plain.serializer() }
         }
     }
 }

--- a/website/docs/bot-config/index.md
+++ b/website/docs/bot-config/index.md
@@ -13,6 +13,7 @@ toc_max_heading_level: 4
 {
     "component": "simbot.qqguild",
     "ticket": {
+        "type": "simple",
         "appId": "APPID",
         "token": "TOKEN",
         "secret": "SECRET"
@@ -48,25 +49,115 @@ toc_max_heading_level: 4
 
 :::
 
-## 配置项
+# 配置项
 
-### component
+## component
 
 固定值 `simbot.qqguild`，**必填**，代表此配置文件为QQ频道组件的。
 
-### ticket
+## ticket
 
 bot的票据信息，**必填**。
 
+- `type`: 配置属性的类型，详见后文
 - `appId`: BotAppID
 - `token`: 机器人令牌
-- `secret`: 机器人密钥 (目前暂时不会用到，可以用 `""` 代替)
+- `secret`: 机器人密钥 (目前可能不会用到，可以用 `""` 代替)
+- 
+### simple
 
-### config
+当 `type=simple` 时，与 `Ticket` 属性基本一致的配置类型， 也是默认的方案。
+
+```json
+{
+  "ticket": {
+    "type": "simple",
+    "appId": "appId-value",
+    "secret": "secret-value",
+    "token": "token-value"
+  }
+}
+```
+
+:::note 省略type
+
+当 simbot-core 版本为 `3.2.0+` 时，`type` 作为默认值 `simple` 时可以省略：
+
+```json
+{
+  "ticket": {
+    "appId": "appId-value",
+    "secret": "secret-value",
+    "token": "token-value"
+  }
+}
+```
+
+:::
+
+### env
+
+当 `type=env` 时，使用环境变量的方式进行配置。
+
+```json
+{
+  "ticket": {
+    "type": "env",
+    "appId": "APP_ID",
+    "secret": "SECRET",
+    "token": "TOKEN",
+    "plain": false
+  }
+}
+```
+
+解析时会首先尝试获取 JVM 参数，即运行时的 `-Dxxx=xxx` （也就是 `System.getProperty`），
+当不存在时会尝试通过环境变量获取（即 `System.getenv`）。
+
+**原始输入**
+
+当 `plain` 为 `true` 时（默认为 `false`），如果某属性通过上述流程无法获取到值，则会尝试直接使用原始输入值。
+
+例如：
+
+```json
+{
+  "ticket": {
+    "type": "env",
+    "appId": "aaa",
+    "secret": "MY_SECRET",
+    "token": "MY_TOKEN",
+    "plain": true
+   }
+}
+```
+
+示例中的 `appId` 并没有找到名为 `aaa` 的 JVM 参数或环境变量，因此它会直接使用 `aaa` 作为 `appId`。 
+而如果 `plain` 为 `false`，则会直接抛出 `IllegalStateException` 异常。
+
+当一个属性以 `PLAIN:` （区分大小写） 为前缀，则会直接使用原始输入值，不会尝试从环境变量中获取。
+
+例如：
+
+```json
+{
+  "ticket": {
+    "type": "env",
+    "appId": "PLAIN:aaa",
+    "secret": "MY_SECRET",
+    "token": "MY_TOKEN",
+    "plain": false
+  }
+}
+```
+
+示例中 `appId` 会直接使用 `aaa` 作为 `appId`，而不会尝试从 JVM 参数或环境变量中获取。
+
+## config
 
 其他配置，可选，默认为 `null`。
 
-#### config.serverUrl
+### config.serverUrl
 
 内部进行API请求时的服务器地址，参考[官方文档](https://bot.q.qq.com/wiki/develop/api/)
 
@@ -90,7 +181,7 @@ bot的票据信息，**必填**。
 }
 ```
 
-#### config.shard
+### config.shard
 
 [分片信息](https://bot.q.qq.com/wiki/develop/api/gateway/shard.html)，默认为 `type=full`，即使用 `[0, 1]` 的分片。
 
@@ -108,7 +199,7 @@ bot的票据信息，**必填**。
 }
 ```
 
-#### config.intents
+### config.intents
 
 [订阅的事件](https://bot.q.qq.com/wiki/develop/api/gateway/intents.html)，默认情况下订阅：
 

--- a/website/docs/bot-config/index.md
+++ b/website/docs/bot-config/index.md
@@ -13,7 +13,7 @@ toc_max_heading_level: 4
 {
     "component": "simbot.qqguild",
     "ticket": {
-        "type": "simple",
+        "type": "plain",
         "appId": "APPID",
         "token": "TOKEN",
         "secret": "SECRET"
@@ -64,14 +64,14 @@ bot的票据信息，**必填**。
 - `token`: 机器人令牌
 - `secret`: 机器人密钥 (目前可能不会用到，可以用 `""` 代替)
 - 
-### simple
+### plain
 
-当 `type=simple` 时，与 `Ticket` 属性基本一致的配置类型， 也是默认的方案。
+当 `type=plain` 时，与 `Ticket` 属性基本一致的配置类型， 也是默认的方案。
 
 ```json
 {
   "ticket": {
-    "type": "simple",
+    "type": "plain",
     "appId": "appId-value",
     "secret": "secret-value",
     "token": "token-value"
@@ -81,7 +81,7 @@ bot的票据信息，**必填**。
 
 :::note 省略type
 
-当 simbot-core 版本为 `3.2.0+` 时，`type` 作为默认值 `simple` 时可以省略：
+当 simbot-core 版本为 `3.2.0+` 时，`type` 作为默认值 `plain` 时可以省略：
 
 ```json
 {


### PR DESCRIPTION
为 `ticket` 属性添加了类别字段 `type`.

原配置：

```json
{
  "ticket": {
    "appId": "appId-value",
    "secret": "secret-value",
    "token": "token-value"
  }
}
```

在 `simbot-core` 版本 **高于等于** `v3.2.0` 时可保持不变，低于时需要修改为：

```json
{
  "ticket": {
    "type": "plain",
    "appId": "appId-value",
    "secret": "secret-value",
    "token": "token-value"
  }
}
```

即增加 `type=plain` 属性来标识多态信息。

同时增加了新的选择：`type=env` 来使用环境变量配置的形式：

```json
{
  "ticket": {
    "type": "env",
    "appId": "APP_ID",
    "secret": "SECRET",
    "token": "TOKEN",
    "plain": false
  }
}
```

有关 `type=env` 的更多特性可参阅**版本发布后**的文档说明。
