### PR TITLE
增加对 `QGEmbed` 的支持

### DIFF
--- a/simbot-component-qq-guild-api/build.gradle.kts
+++ b/simbot-component-qq-guild-api/build.gradle.kts
@@ -17,23 +17,6 @@
 
 import love.forte.gradle.common.kotlin.multiplatform.NativeTargets
 
-/*
- * Copyright (c) 2023. ForteScarlet.
- *
- * This file is part of simbot-component-qq-guild.
- *
- * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
- *
- * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
- * If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     kotlin("multiplatform")
     `qq-guild-multiplatform-maven-publish`
@@ -110,7 +93,7 @@ kotlin {
 ////        "watchosDeviceArm64",
 //    )
 
-    val targets = NativeTargets.Official.all.intersect(NativeTargets.Ktor.all) + setOf("mingwX64")
+    val targets = NativeTargets.Official.all.intersect(NativeTargets.KtorClient.all) + setOf("mingwX64")
 
     targets {
         presets.filterIsInstance<org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeTargetPreset<*>>()

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/MessageSendApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/MessageSendApi.kt
@@ -238,7 +238,7 @@ public class MessageSendApi private constructor(
         public val content: String?,
 
         /**
-         * 选填，embed 消息，一种特殊的 ark，详情参考[Embed消息](https://bot.q.qq.com/wiki/develop/api/openapi/message/embed_message.html)
+         * 选填，embed 消息，一种特殊的 ark，详情参考 [Embed消息](https://bot.q.qq.com/wiki/develop/api/openapi/message/template/embed_message.html)
          */
         public val embed: Message.Embed?,
         /**
@@ -311,6 +311,12 @@ public class MessageSendApi private constructor(
             public var msgId: String? = null
             public var eventId: String? = null
             public var markdown: Message.Markdown? = null
+
+            /**
+             * 判断 [Builder] 中的各属性是否都为空
+             */
+            public val isEmpty: Boolean
+                get() = content == null && embed == null && ark == null && messageReference == null && image == null && msgId == null && eventId == null && markdown == null
 
             public fun appendContent(append: String) {
                 if (content == null) {
@@ -399,6 +405,7 @@ public inline fun MessageSendApi.Factory.create(channelId: String, builder: Buil
  * 提供一些需要由不同平台额外实现的基类。
  * 主要针对 `fileImage`。
  */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @InternalApi
 public expect abstract class BaseMessageSendBodyBuilder() {
     public open var fileImage: Any?

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/message/MessageBuilders.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/message/MessageBuilders.kt
@@ -16,6 +16,7 @@
  */
 
 @file:Suppress("MemberVisibilityCanBePrivate")
+
 package love.forte.simbot.qguild.message
 
 import love.forte.simbot.qguild.model.Message
@@ -174,24 +175,53 @@ public class EmbedBuilder {
      */
     public lateinit var prompt: String
 
-
     /**
      * 缩略图
+     *
+     * 选填，没有缩略图的可以不填
      */
-    public lateinit var thumbnail: Message.Embed.Thumbnail
+    public var thumbnail: Message.Embed.Thumbnail? = null
 
+    /**
+     * 设置缩略图。
+     *
+     * @see thumbnail
+     */
+    public var thumbnailUrl: String?
+        get() = thumbnail?.url
+        set(value) {
+            thumbnail = if (value == null) {
+                null
+            } else {
+                Message.Embed.Thumbnail(value)
+            }
+        }
 
     /**
      * MessageEmbedField 对象数组	字段信息
      */
     public var fields: MutableList<Message.Embed.Field> = mutableListOf()
 
-
+    /**
+     * 向 [fields] 中添加一个元素。
+     *
+     */
+    @Deprecated("'value' is deprecated.", ReplaceWith("addField(name)"))
     public fun addField(name: String, value: String) {
-        fields.add(Message.Embed.Field(name, value))
+        addField(name)
     }
 
+    /**
+     * 向 [fields] 中添加一个元素。
+     *
+     */
+    public fun addField(name: String) {
+        fields.add(Message.Embed.Field(name))
+    }
 
+    /**
+     * 构建得到 [Message.Embed]
+     */
     public fun build(): Message.Embed {
         return Message.Embed(title, prompt, thumbnail, fields.toList())
     }

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.message.EmbedBuilder
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -149,7 +150,9 @@ public data class Message(
     }
 
     /**
-     * [MessageEmbed](https://bot.q.qq.com/wiki/develop/api/openapi/message/model.html#messageembed)
+     * [embed 消息](https://bot.q.qq.com/wiki/develop/api/openapi/message/template/embed_message.html)
+     *
+     * @see EmbedBuilder
      */
     @Serializable
     public data class Embed(
@@ -164,9 +167,9 @@ public data class Message(
         val prompt: String,
 
         /**
-         * 缩略图
+         * 缩略图，选填
          */
-        val thumbnail: Thumbnail,
+        val thumbnail: Thumbnail? = null,
 
         /**
          * 字段信息
@@ -202,7 +205,8 @@ public data class Message(
              * _Note: 似乎已经不存在了_
              */
             @Deprecated("not exists", level = DeprecationLevel.HIDDEN)
-            public val value: String = "",
+            @Transient
+            public val value: String? = null,
         )
     }
 

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QQGuildComponent.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QQGuildComponent.kt
@@ -115,6 +115,7 @@ public class QQGuildComponent : Component {
                 subclass(QGReplyTo.serializer())
                 subclass(QGContentText.serializer())
                 subclass(QGReference.serializer())
+                subclass(QGEmbed.serializer())
 
                 @Suppress("DEPRECATION")
                 subclass(QGAtChannel.serializer())

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/message/QGEmbed.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/message/QGEmbed.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.message
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import love.forte.simbot.event.MessageEvent
+import love.forte.simbot.message.Messages
+import love.forte.simbot.message.doSafeCast
+import love.forte.simbot.qguild.api.message.MessageSendApi
+import love.forte.simbot.qguild.message.EmbedBuilder
+import love.forte.simbot.qguild.model.Message
+
+
+/**
+ *
+ * embed 消息，一种特殊的 ark。
+ *
+ * [QGEmbed] 是针对 [Message.Embed] 类型的消息元素实现，在发送时会被作为一个 **独立的** [MessageSendApi] (的 `embed` 属性) 发送。
+ *
+ * 更多参考 [文档](https://bot.q.qq.com/wiki/develop/api/openapi/message/template/embed_message.html)
+ *
+ * Note: [QGEmbed] 似乎不能与 [MessageSendApi.Body.messageReference] 配合使用，
+ * 也就是尽可能不要在 [MessageEvent.reply] 中使用 [QGEmbed], 否则会导致此消息不可见。
+ *
+ * @see Message.Embed
+ * @see MessageSendApi.Body.embed
+ *
+ * @property embed 对应的 [Message.Embed] 内容。
+ *
+ * @author ForteScarlet
+ */
+@SerialName("qg.embed")
+@Serializable
+public data class QGEmbed internal constructor(public val embed: Message.Embed) : QGMessageElement<QGEmbed> {
+    override val key: love.forte.simbot.message.Message.Key<QGEmbed>
+        get() = Key
+
+    public companion object Key : love.forte.simbot.message.Message.Key<QGEmbed> {
+        override fun safeCast(value: Any): QGEmbed? = doSafeCast(value)
+
+        /**
+         * 将提供的 [Message.Embed] 包装为 [QGEmbed]。
+         */
+        @JvmStatic
+        public fun byEmbed(embed: Message.Embed): QGEmbed = QGEmbed(embed)
+    }
+}
+
+/**
+ * 使用 [EmbedBuilder] 构建并得到 [QGEmbed]。
+ *
+ * @see QGEmbed
+ */
+public inline fun buildQGEmbed(block: EmbedBuilder.() -> Unit): QGEmbed =
+    QGEmbed.byEmbed(EmbedBuilder().also(block).build())
+
+
+internal object EmbedParser : SendingMessageParser {
+    override suspend fun invoke(
+        index: Int,
+        element: love.forte.simbot.message.Message.Element<*>,
+        messages: Messages?,
+        builderContext: SendingMessageParser.BuilderContext
+    ) {
+        if (element is QGEmbed) {
+            val embed = element.embed
+            // 必须是一个全空的 builder。
+            val builder = builderContext.builderOrNew { builder -> builder.isEmpty }
+            builder.embed = embed
+            // 下一次必须是另外新建的builder
+            builderContext.nextMustBeNew()
+        }
+    }
+}


### PR DESCRIPTION
增加新的核心模块消息元素类型 `QGEmbed` 来提供对 [embed](https://bot.q.qq.com/wiki/develop/api/openapi/message/template/embed_message.html) 类型消息的支持。

```kotlin
val channel = ...
// 构建消息并发送
channel.send(buildQGEmbed { 
    title = "标题"
    prompt = "弹窗消息内容"
    addField("当前等级：黄金")
    addField("之前等级：白银")
})
```

Java:
```java
Channel channel = ...;

// 构建 Embed 对象
final EmbedBuilder builder = new EmbedBuilder();
builder.setTitle("标题");
builder.setPrompt("弹窗消息内容");
builder.addField("当前等级：黄金");
builder.addField("之前等级：白银");

// 构建 QGEmbed 对象
final QGEmbed qgEmbed = QGEmbed.byEmbed(builder.build());

channel.sendBlocking(qgEmbed);
```

`QGEmbed` 占有一条独立的消息位，如果与其他消息合并发送（例如文本消息：`"".toText() + buildQGEmbed { ... }` ）则消息会被切割为多条。

close https://github.com/simple-robot/simbot-component-qq-guild/issues/107