### PR TITLE
废弃 `registerProcessor`, `registerPreProcessor`, `Bot.process` 并重命名为统一的 `subscribe`

### DIFF
--- a/.github/workflows/deploy-v4-website.yml
+++ b/.github/workflows/deploy-v4-website.yml
@@ -26,7 +26,7 @@ env:
   # Replace HI with the ID of the instance in capital letters
   ARTIFACT: webHelpQG2-all.zip
   # Writerside docker image version
-  DOCKER_VERSION: 233.14272
+  DOCKER_VERSION: 233.14389
   # Add the variable below to upload Algolia indexes
   # Replace HI with the ID of the instance in capital letters
   ALGOLIA_ARTIFACT: algolia-indexes-QG.zip

--- a/.github/workflows/doc-test-branch.yml
+++ b/.github/workflows/doc-test-branch.yml
@@ -36,6 +36,14 @@ jobs:
             artifacts/report.json
           retention-days: 7
 
+      - name: Upload documentation reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: 'report.json'
+          path: artifacts/report.json
+          retention-days: 7
+
   # Add the job below and artifacts/report.json on Upload documentation step above if you want to fail the build when documentation contains errors
   test:
     name: Test documentation built

--- a/.github/workflows/doc-test-branch.yml
+++ b/.github/workflows/doc-test-branch.yml
@@ -12,6 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Name of module and id separated by a slash
+  INSTANCE: Writerside/qg
+  INSTANCE_NAME: qg
+  # Replace HI with the ID of the instance in capital letters
+  ARTIFACT: webHelpQG2-all.zip
+  # Writerside docker image version
+  DOCKER_VERSION: 233.14389
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,7 +50,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: 'report.json'
-          path: artifacts/report.json
+          path: artifacts/**
           retention-days: 7
 
   # Add the job below and artifacts/report.json on Upload documentation step above if you want to fail the build when documentation contains errors

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -54,5 +54,5 @@ jobs:
         if: ${{ always() }}
         with:
           name: test-reports-${{ matrix.os }}
-          path: build/test-reports
+          path: '**/build/reports/tests'
           retention-days: 7

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -48,3 +48,11 @@ jobs:
 #            --build-cache
 #            -Porg.gradle.daemon=false
 #            -Porg.gradle.jvmargs="-Xmx4g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: build/test-reports
+          retention-days: 7

--- a/Writerside/topics/QGBot.md
+++ b/Writerside/topics/QGBot.md
@@ -157,7 +157,7 @@ var bot = BotFactory.create(botId, botSecret, botToken, configuration);
 
 ### 订阅事件 {id='bot-subscribe-event'}
 
-你可以通过 `registerProcessor` 来订阅全部或指定类型的事件。
+你可以通过 `subscribe` 来订阅全部或指定类型的事件。
 
 <tip>
 
@@ -173,10 +173,10 @@ var bot = BotFactory.create(botId, botSecret, botToken, configuration);
 
 **订阅全部事件**
 
-使用 `registerProcessor` 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件。
+使用 `subscribe` 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件。
 
 ```Kotlin
-bot.registerProcessor { raw ->
+bot.subscribe { raw ->
     // raw 代表事件的原始JSON字符串
     // this: Signal.Dispatch, 也就是解析出来的事件结构体
     println("event: $this")
@@ -187,7 +187,7 @@ bot.registerProcessor { raw ->
 
 **订阅指定类型的事件**
 
-使用扩展函数 `registerProcessor` 注册一个针对具体 `Signal.Dispatch` 事件类型的事件处理器，
+使用扩展函数 `subscribe` 注册一个针对具体 `Signal.Dispatch` 事件类型的事件处理器，
 它只有在接收到的 `Signal.Dispatch` 与目标类型一致时才会处理。
 
 此示例展示处理 `AtMessageCreate` 也就公域是消息事件，
@@ -208,10 +208,10 @@ bot.process<AtMessageCreate> {
 
 **订阅全部事件**
 
-使用 `registerProcessor` 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件。
+使用 `subscribe` 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件。
 
 ```Java
-bot.registerProcessor(EventProcessors.async((event, raw) -> {
+bot.subscribe(EventProcessors.async((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Signal.Dispatch, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -225,7 +225,7 @@ bot.registerProcessor(EventProcessors.async((event, raw) -> {
 {switcher-key="%ja%"}
 
 ```Java
-bot.registerProcessor(EventProcessors.block((event, raw) -> {
+bot.subscribe(EventProcessors.block((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Signal.Dispatch, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -237,14 +237,14 @@ bot.registerProcessor(EventProcessors.block((event, raw) -> {
 
 **订阅指定类型的事件**
 
-使用 `registerProcessor` 注册一个指定了具体类型的事件处理器，
+使用 `subscribe` 注册一个指定了具体类型的事件处理器，
 它只有在接收到的 `Signal.Dispatch` 与目标类型一致时才会处理。
 
 此示例展示处理 `AtMessageCreate` 也就公域是消息事件，
 并在对方发送了包含 `"stop"` 的文本时终止 bot。
 
 ```Java
-bot.registerProcessor(EventProcessors.async(AtMessageCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.async(AtMessageCreate.class, (event, raw) -> {
     if (event.getData().getContent().contains("stop")) {
         // 终止 bot
         bot.cancel();
@@ -256,7 +256,7 @@ bot.registerProcessor(EventProcessors.async(AtMessageCreate.class, (event, raw) 
 {switcher-key="%ja%"}
 
 ```Java
-bot.registerProcessor(EventProcessors.block(AtMessageCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.block(AtMessageCreate.class, (event, raw) -> {
     if (event.getData().getContent().contains("stop")) {
         // 终止 bot
         bot.cancel();

--- a/Writerside/topics/QGGuild.md
+++ b/Writerside/topics/QGGuild.md
@@ -35,7 +35,7 @@ bot.process<GuildCreate> {
 <tab title="Java" group-key="Java">
 
 ```Java
-bot.registerProcessor(EventProcessors.async(GuildCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.async(GuildCreate.class, (event, raw) -> {
     EventGuild guild = event.getData();
     // ...
     return CompletableFuture.completedFuture(null);
@@ -44,7 +44,7 @@ bot.registerProcessor(EventProcessors.async(GuildCreate.class, (event, raw) -> {
 {switcher-key="%ja%"}
 
 ```Java
-bot.registerProcessor(EventProcessors.block(GuildCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.block(GuildCreate.class, (event, raw) -> {
     EventGuild guild = event.getData();
 }));
 ```

--- a/Writerside/topics/embed/api_embed.md
+++ b/Writerside/topics/embed/api_embed.md
@@ -7,7 +7,10 @@ QQ频道中有一些针对 `Embed消息` 的API。
 
 `Embed`
 
+TODO
 
 ## 组件库模块 {id='core-module'}
 
 `QGEmbed`
+
+TODO

--- a/Writerside/topics/forum/api_forum.md
+++ b/Writerside/topics/forum/api_forum.md
@@ -391,7 +391,7 @@ Bot bot = BotFactory.create("appid", "sec", "token", (config) -> {
         );
     });
 
-bot.registerProcessor(EventProcessors.async(OpenForumThreadCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.async(OpenForumThreadCreate.class, (event, raw) -> {
         System.out.println("OpenForumThreadCreate:     " + event);
         System.out.println("OpenForumThreadCreate.raw: " + raw);
         return CompletableFuture.completedFuture(null); // Void?

--- a/Writerside/topics/tips-send-image.md
+++ b/Writerside/topics/tips-send-image.md
@@ -6,7 +6,7 @@
 
 ## API模块 {id='api-module'}
 
-假如你只使用了API模块，那么就需要普通地API的正常流程来发送图片: 
+假如你只使用了API模块，那么就需要普通地使用API来发送图片: 
 使用 `MessageSendApi` 中的 `fileImage` 或 `image` 属性上传图片。
 
 其中 `image` 比较简单，就是一个图片的地址。

--- a/Writerside/topics/use-stdlib.md
+++ b/Writerside/topics/use-stdlib.md
@@ -134,9 +134,9 @@ val bot = BotFactory.create(ticket) {
 }
 
 // 注册事件有一些不同但类似的方式
-// 1️⃣ 通过 registerProcessor 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件
-//     registerProcessor 是最基本的注册方式，也是其他方式的最终汇集点
-bot.registerProcessor { raw ->
+// 1️⃣ 通过 subscribe 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件
+//     subscribe 是最基本的注册方式，也是其他方式的最终汇集点
+bot.subscribe { raw ->
     // raw 代表事件的原始JSON字符串
     // this: Signal.Dispatch, 也就是解析出来的事件结构体
     println("event: $this")
@@ -193,9 +193,9 @@ Bot bot = BotFactory.create(ticket, config -> {
     // 其他各种配置...
 });
 
-// 通过 registerProcessor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理所有类型的事件
-bot.registerProcessor(EventProcessors.async((event, raw) -> {
+bot.subscribe(EventProcessors.async((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Signal.Dispatch, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -206,10 +206,10 @@ bot.registerProcessor(EventProcessors.async((event, raw) -> {
     return CompletableFuture.completedFuture(null);
 }));
 
-// 通过 registerProcessor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理指定的类型 AtMessageCreate 的事件
 // 此示例展示处理 AtMessageCreate 也就公域是消息事件，并在对方发送了包含 'stop' 的文本时终止 bot。
-bot.registerProcessor(EventProcessors.async(AtMessageCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.async(AtMessageCreate.class, (event, raw) -> {
     System.out.println("event message: $data");
 
     if (event.getData().getContent().contains("stop")) {
@@ -258,9 +258,9 @@ Bot bot = BotFactory.create(ticket, config -> {
     // 其他各种配置...
 });
 
-// 通过 registerProcessor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理所有类型的事件
-bot.registerProcessor(EventProcessors.block((event, raw) -> {
+bot.subscribe(EventProcessors.block((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Signal.Dispatch, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -268,10 +268,10 @@ bot.registerProcessor(EventProcessors.block((event, raw) -> {
     System.out.println("raw: " + raw);
 }));
 
-// 通过 registerProcessor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理指定的类型 AtMessageCreate 的事件
 // 此示例展示处理 AtMessageCreate 也就公域是消息事件，并在对方发送了包含 'stop' 的文本时终止 bot。
-bot.registerProcessor(EventProcessors.block(AtMessageCreate.class, (event, raw) -> {
+bot.subscribe(EventProcessors.block(AtMessageCreate.class, (event, raw) -> {
     System.out.println("event message: $data");
 
     if (event.getData().getContent().contains("stop")) {

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -40,7 +40,10 @@ inline fun KotlinJvmTarget.configJava(crossinline block: KotlinJvmTarget.() -> U
     }
 
     testRuns["test"].executionTask.configure {
-        useJUnitPlatform()
+        useJUnitPlatform {
+            val dir = project.rootProject.layout.buildDirectory.dir("test-reports/html/${project.name}")
+            reports.html.outputLocation.set(dir)
+        }
     }
     block()
 }

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -41,7 +41,7 @@ inline fun KotlinJvmTarget.configJava(crossinline block: KotlinJvmTarget.() -> U
 
     testRuns["test"].executionTask.configure {
         useJUnitPlatform {
-            val dir = project.rootProject.layout.buildDirectory.dir("test-reports/html/${project.name}")
+            val dir = project.rootProject.layout.buildDirectory.dir("test-reports/jvm/html/${project.name}")
             reports.html.outputLocation.set(dir)
         }
     }

--- a/buildSrc/src/main/kotlin/qq-guild-module-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/qq-guild-module-config.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+

--- a/simbot-component-qq-guild-api/build.gradle.kts
+++ b/simbot-component-qq-guild-api/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     kotlin("plugin.serialization")
     `qq-guild-dokka-partial-configure`
     alias(libs.plugins.ksp)
+    `qq-guild-module-config`
 }
 
 setup(P.ComponentQQGuild)

--- a/simbot-component-qq-guild-core/build.gradle.kts
+++ b/simbot-component-qq-guild-core/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     kotlin("plugin.serialization")
     `qq-guild-dokka-partial-configure`
     `simbot-tcg-suspend-transform-configure`
+    `qq-guild-module-config`
 }
 
 setup(P.ComponentQQGuild)

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGEventProcess.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGEventProcess.kt
@@ -49,7 +49,7 @@ private fun QGBotImpl.member0(eventMember: EventMember): QGMemberImpl =
  */
 internal fun QGBotImpl.registerEventProcessor(): DisposableHandle {
     val bot = this
-    return source.registerProcessor { raw ->
+    return source.subscribe { raw ->
         when (val event = this) {
             //region Guild相关
             is GuildCreate -> {

--- a/simbot-component-qq-guild-stdlib/README.md
+++ b/simbot-component-qq-guild-stdlib/README.md
@@ -113,7 +113,7 @@ val bot = BotFactory.create(
 
 // 订阅事件。事件类型参考 Signal.Dispatch 的实现类类型
 // 监听Signal.Dispatch即代表监听所有事件
-bot.registerProcessor<Signal.Dispatch> { raw ->
+bot.subscribe<Signal.Dispatch> { raw ->
     // 当前函数 receiver 即为事件本体
     println(this) // -> this: 事件本体
     // 函数体参数为事件的原始JSON字符串
@@ -121,7 +121,7 @@ bot.registerProcessor<Signal.Dispatch> { raw ->
 }
 
 // 监听频道信息更新事件
-bot.registerProcessor<GuildUpdate> { raw ->
+bot.subscribe<GuildUpdate> { raw ->
     this.data.opUserId // 操作人ID
 
     // 事件中请求API
@@ -129,7 +129,7 @@ bot.registerProcessor<GuildUpdate> { raw ->
     println(member)
 }
 
-bot.registerProcessor { raw ->
+bot.subscribe { raw ->
     // 订阅所有事件
 }
 

--- a/simbot-component-qq-guild-stdlib/build.gradle.kts
+++ b/simbot-component-qq-guild-stdlib/build.gradle.kts
@@ -72,6 +72,7 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
         }
 
         jvmTest.dependencies {

--- a/simbot-component-qq-guild-stdlib/build.gradle.kts
+++ b/simbot-component-qq-guild-stdlib/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     kotlin("plugin.serialization")
     `qq-guild-dokka-partial-configure`
     `simbot-tcg-suspend-transform-configure`
+    `qq-guild-module-config`
 }
 
 setup(P.ComponentQQGuild)

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/BotProcessor.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/BotProcessor.kt
@@ -23,16 +23,34 @@ import love.forte.simbot.qguild.event.Signal
  * 用当前 [Bot] 订阅一个指定类型 [E] 的事件。
  *
  * ```kotlin
- * bot.registerProcessor<Signal.Dispatch> { raw ->
+ * bot.process<Signal.Dispatch> { raw ->
  *      // ...
  * }
  * ```
  *
  */
+@Deprecated(
+    "Use `subscribe`", ReplaceWith("this.subscribe<E>(SubscribeSequence.NORMAL, block)"),
+)
 public inline fun <reified E : Signal.Dispatch> Bot.process(
     crossinline block: suspend E.(raw: String) -> Unit
+): DisposableHandle = subscribe<E>(SubscribeSequence.NORMAL, block)
+
+/**
+ * 用当前 [Bot] 订阅一个指定类型 [E] 的事件。
+ *
+ * ```kotlin
+ * bot.subscribe<Signal.Dispatch> { raw ->
+ *      // ...
+ * }
+ * ```
+ *
+ */
+public inline fun <reified E : Signal.Dispatch> Bot.subscribe(
+    sequence: SubscribeSequence = SubscribeSequence.NORMAL,
+    crossinline block: suspend E.(raw: String) -> Unit
 ): DisposableHandle {
-    return registerProcessor { raw ->
+    return subscribe(sequence) { raw ->
         if (this is E) {
             block(raw)
         }

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/internal/BotImpl.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/internal/BotImpl.kt
@@ -161,14 +161,19 @@ internal class BotImpl(
     internal val preProcessorQueue: ConcurrentQueue<EventProcessor> = createConcurrentQueue()
 
 
-    override fun registerPreProcessor(processor: EventProcessor): DisposableHandle {
-        preProcessorQueue.add(processor)
-        return DisposableHandleImpl(preProcessorQueue, processor)
-    }
+    override fun subscribe(sequence: SubscribeSequence, processor: EventProcessor): DisposableHandle {
+        return when (sequence) {
+            SubscribeSequence.PRE -> {
+                preProcessorQueue.add(processor)
+                DisposableHandleImpl(preProcessorQueue, processor)
+            }
 
-    override fun registerProcessor(processor: EventProcessor): DisposableHandle {
-        processorQueue.add(processor)
-        return DisposableHandleImpl(processorQueue, processor)
+            SubscribeSequence.NORMAL -> {
+
+                processorQueue.add(processor)
+                DisposableHandleImpl(processorQueue, processor)
+            }
+        }
     }
 
     private class DisposableHandleImpl(queue: ConcurrentQueue<EventProcessor>, subject: EventProcessor) :

--- a/simbot-component-qq-guild-stdlib/src/commonTest/kotlin/BotSubscribeRegisterTest.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonTest/kotlin/BotSubscribeRegisterTest.kt
@@ -1,3 +1,4 @@
+import io.ktor.client.engine.mock.*
 import love.forte.simbot.qguild.event.GuildCreate
 import love.forte.simbot.qguild.stdlib.Bot
 import love.forte.simbot.qguild.stdlib.ConfigurableBotConfiguration
@@ -19,7 +20,10 @@ class BotSubscribeRegisterTest {
     fun subscribeTest() {
         val bot = BotImpl(
             Bot.Ticket("", "", ""),
-            ConfigurableBotConfiguration()
+            ConfigurableBotConfiguration().apply {
+                apiClientEngine = MockEngine { respondOk() }
+                wsClientEngine = MockEngine { respondOk() }
+            }
         )
 
         bot.subscribe {

--- a/simbot-component-qq-guild-stdlib/src/commonTest/kotlin/BotSubscribeRegisterTest.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonTest/kotlin/BotSubscribeRegisterTest.kt
@@ -1,0 +1,32 @@
+import love.forte.simbot.qguild.event.GuildCreate
+import love.forte.simbot.qguild.stdlib.Bot
+import love.forte.simbot.qguild.stdlib.ConfigurableBotConfiguration
+import love.forte.simbot.qguild.stdlib.internal.BotImpl
+import love.forte.simbot.qguild.stdlib.subscribe
+import kotlin.test.Test
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class BotSubscribeRegisterTest {
+
+    /**
+     * 确保普通的 subscribe 和同名扩展函数
+     * 不会产生冲突。
+     */
+    @Test
+    fun subscribeTest() {
+        val bot = BotImpl(
+            Bot.Ticket("", "", ""),
+            ConfigurableBotConfiguration()
+        )
+
+        bot.subscribe {
+        }
+
+        bot.subscribe<GuildCreate> {
+        }
+    }
+
+}

--- a/website/docs/api/forum/index.md
+++ b/website/docs/api/forum/index.md
@@ -374,7 +374,7 @@ val bot = BotFactory.create("app id", "sec", "token") {
     intents += EventIntents.OpenForumsEvent.intents
 }
 
-bot.registerProcessor<OpenForumThreadCreate> { raw ->
+bot.subscribe<OpenForumThreadCreate> { raw ->
     println("OpenForumThreadCreate:     $this")
     println("OpenForumThreadCreate.raw: $raw")
 }


### PR DESCRIPTION
```kotlin
bot.subscribe { ... }
bot.subscribe<EventType> { ... }
```