### PR TITLE
为部分类型的属性增加反序列化默认值

### DIFF
--- a/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
+++ b/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
@@ -4313,6 +4313,7 @@ public final class love/forte/simbot/qguild/model/MessageAudited$Companion {
 
 public final class love/forte/simbot/qguild/model/MessageMember : love/forte/simbot/qguild/model/Member {
 	public static final field Companion Llove/forte/simbot/qguild/model/MessageMember$Companion;
+	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun asMessageMember (Llove/forte/simbot/qguild/model/Member;)Llove/forte/simbot/qguild/model/MessageMember;

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. ForteScarlet.
+ * Copyright (c) 2022-2024. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -25,6 +25,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
 import love.forte.simbot.qguild.message.EmbedBuilder
+import love.forte.simbot.qguild.time.ZERO_ISO_INSTANT
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -359,10 +360,10 @@ public data class Message(
 @ApiModel
 @Serializable
 public data class MessageMember(
-    override val nick: String,
+    override val nick: String = "",
     override val roles: List<String> = emptyList(),
     @SerialName("joined_at")
-    override val joinedAt: String
+    override val joinedAt: String = ZERO_ISO_INSTANT
 ) : Member {
 
     @Transient


### PR DESCRIPTION
例如 `MessageMember.nick`, 在私聊会话中实际上并无此属性。