### PR TITLE
为 QGMember 提供不用请求API的 defaultRoles 属性来获取仅基于默认身份组的身份组列表

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -56,8 +56,8 @@ object P {
         override val homepage: String get() = HOMEPAGE
 
 
-        const val VERSION = "4.0.0-beta8"
-        const val NEXT_VERSION = "4.0.0-beta9"
+        const val VERSION = "4.0.0-beta9"
+        const val NEXT_VERSION = "4.0.0-beta10"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"
         override val version = if (isSnapshot()) snapshotVersion else VERSION

--- a/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
+++ b/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
@@ -5715,6 +5715,10 @@ public final class love/forte/simbot/qguild/model/Role {
 	public static final field DEFAULT_ID_ALL_MEMBER Ljava/lang/String;
 	public static final field DEFAULT_ID_CHANNEL_ADMIN Ljava/lang/String;
 	public static final field DEFAULT_ID_OWNER Ljava/lang/String;
+	public static final field DefaultAdmin Llove/forte/simbot/qguild/model/Role;
+	public static final field DefaultAllMember Llove/forte/simbot/qguild/model/Role;
+	public static final field DefaultChannelAdmin Llove/forte/simbot/qguild/model/Role;
+	public static final field DefaultOwner Llove/forte/simbot/qguild/model/Role;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;IIII)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -5750,6 +5754,7 @@ public synthetic class love/forte/simbot/qguild/model/Role$$serializer : kotlinx
 }
 
 public final class love/forte/simbot/qguild/model/Role$Companion {
+	public final fun defaultRole (Ljava/lang/String;)Llove/forte/simbot/qguild/model/Role;
 	public final fun isDefault (Ljava/lang/String;)Z
 	public final fun isDefault (Llove/forte/simbot/qguild/model/Role;)Z
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Role.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Role.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2024. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -25,6 +25,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
+import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 /**
@@ -117,6 +118,103 @@ public data class Role(
         @get:JvmStatic
         public val Role.isDefault: Boolean get() = isDefault(id)
 
+        /**
+         * [DefaultRoleIDs(系统默认生成下列身份组ID)](https://bot.q.qq.com/wiki/develop/api/openapi/guild/role_model.html)
+         *
+         * 此为一个默认构造的离线类型，其中的部分属性使用默认值填充。
+         *
+         * 1: 全体成员
+         *
+         * @see DEFAULT_ID_ALL_MEMBER
+         */
+        @JvmField
+        public val DefaultAllMember: Role =
+            Role(
+                id = DEFAULT_ID_ALL_MEMBER,
+                name = "全体成员",
+                color = 0,
+                hoist = 0,
+                number = -1,
+                memberLimit = -1
+            )
+
+        /**
+         * [DefaultRoleIDs(系统默认生成下列身份组ID)](https://bot.q.qq.com/wiki/develop/api/openapi/guild/role_model.html)
+         *
+         * 此为一个默认构造的离线类型，其中的部分属性使用默认值填充。
+         *
+         * 2: 管理员
+         *
+         * @see DEFAULT_ID_ADMIN
+         */
+        @JvmField
+        public val DefaultAdmin: Role =
+            Role(
+                id = DEFAULT_ID_ADMIN,
+                name = "管理员",
+                color = 0,
+                hoist = 0,
+                number = -1,
+                memberLimit = -1
+            )
+
+        /**
+         * [DefaultRoleIDs(系统默认生成下列身份组ID)](https://bot.q.qq.com/wiki/develop/api/openapi/guild/role_model.html)
+         *
+         * 此为一个默认构造的离线类型，其中的部分属性使用默认值填充。
+         *
+         * 4: 群主/创建者
+         *
+         * @see DEFAULT_ID_OWNER
+         */
+        @JvmField
+        public val DefaultOwner: Role =
+            Role(
+                id = DEFAULT_ID_OWNER,
+                name = "群主/创建者",
+                color = 0,
+                hoist = 0,
+                number = -1,
+                memberLimit = -1
+            )
+
+        /**
+         * [DefaultRoleIDs(系统默认生成下列身份组ID)](https://bot.q.qq.com/wiki/develop/api/openapi/guild/role_model.html)
+         *
+         * 此为一个默认构造的离线类型，其中的部分属性使用默认值填充。
+         *
+         * 5: 子频道管理员
+         *
+         * @see DEFAULT_ID_CHANNEL_ADMIN
+         */
+        @JvmField
+        public val DefaultChannelAdmin: Role =
+            Role(
+                id = DEFAULT_ID_CHANNEL_ADMIN,
+                name = "子频道管理员",
+                color = 0,
+                hoist = 0,
+                number = -1,
+                memberLimit = -1
+            )
+
+        /**
+         * 得到一个 [id] 对应的默认角色实例。
+         *
+         * - [DefaultAllMember]
+         * - [DefaultAdmin]
+         * - [DefaultOwner]
+         * - [DefaultChannelAdmin]
+         *
+         * @throws IllegalArgumentException 如果 `id` 不在 [isDefault] 范围内。
+         */
+        public fun defaultRole(id: String): Role = when (id) {
+            DEFAULT_ID_ALL_MEMBER -> DefaultAllMember
+            DEFAULT_ID_ADMIN -> DefaultAdmin
+            DEFAULT_ID_OWNER -> DefaultOwner
+            DEFAULT_ID_CHANNEL_ADMIN -> DefaultChannelAdmin
+            else -> throw IllegalArgumentException("Id $id is not a default role id.")
+        }
     }
 }
 

--- a/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
+++ b/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
@@ -1465,6 +1465,7 @@ public abstract interface class love/forte/simbot/component/qguild/guild/QGMembe
 	public fun getJoinTime ()Llove/forte/simbot/common/time/Timestamp;
 	public fun getName ()Ljava/lang/String;
 	public fun getNick ()Ljava/lang/String;
+	public fun getRoleIds ()Ljava/util/List;
 	public abstract fun mute (JLjava/util/concurrent/TimeUnit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract synthetic fun mute-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun muteAsync (JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/CompletableFuture;

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/guild/QGMember.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/guild/QGMember.kt
@@ -38,6 +38,9 @@ import love.forte.simbot.message.Text
 import love.forte.simbot.qguild.QQGuildApiException
 import love.forte.simbot.qguild.api.MessageAuditedException
 import love.forte.simbot.qguild.api.guild.mute.MuteMemberApi
+import love.forte.simbot.qguild.api.role.GetGuildRoleListApi
+import love.forte.simbot.qguild.model.Role
+import love.forte.simbot.qguild.model.Role.Companion.isDefault
 import love.forte.simbot.suspendrunner.ST
 import kotlin.jvm.JvmSynthetic
 import kotlin.time.Duration
@@ -81,10 +84,30 @@ public interface QGMember : Member, CoroutineScope, QGObjectiveContainer<QGSourc
         get() = source.joinedAt.toTimestamp()
 
     /**
-     * 成员拥有的角色
+     * 成员 [source] 拥有的身分组ID集合。
+     *
+     * @see QGSourceMember.roles
+     */
+    public val roleIds: List<String>
+        get() = source.roles
+
+    /**
+     * 成员拥有的角色，会通过 [GetGuildRoleListApi] 进行查询。
+     * 如果不希望请求API以避免出现无访问权限的情况，可考虑使用离线的 [defaultRoles]。
      */
     @ExperimentalQGApi
     public val roles: Collectable<QGMemberRole>
+
+    /**
+     * 从 [source.roles][QGSourceMember.roles] 中直接构建的离线的默认 [QGMemberRole] 列表。
+     * 这个过程不会发起API请求，但是得到的 [QGMemberRole] 中可能存在部分属性缺失 (例如 `color`)，
+     * 这些缺失的属性会使用一个默认值填充。
+     *
+     * @see Role.isDefault
+     * @see Role.defaultRole
+     */
+    @ExperimentalQGApi
+    public val defaultRoles: List<QGMemberRole>
 
     /**
      * 向目标成员发送私聊消息。

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/guild/QGMemberImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/guild/QGMemberImpl.kt
@@ -30,6 +30,8 @@ import love.forte.simbot.component.qguild.guild.QGMember
 import love.forte.simbot.component.qguild.internal.bot.QGBotImpl
 import love.forte.simbot.component.qguild.internal.bot.newSupervisorCoroutineContext
 import love.forte.simbot.component.qguild.internal.message.asReceipt
+import love.forte.simbot.component.qguild.internal.role.toGuildRole
+import love.forte.simbot.component.qguild.internal.role.toMemberRole
 import love.forte.simbot.component.qguild.message.MessageParsers
 import love.forte.simbot.component.qguild.message.QGMessageContent
 import love.forte.simbot.component.qguild.message.QGMessageReceipt
@@ -44,6 +46,7 @@ import love.forte.simbot.qguild.api.message.MessageSendApi
 import love.forte.simbot.qguild.api.message.direct.CreateDmsApi
 import love.forte.simbot.qguild.api.message.direct.DmsSendApi
 import love.forte.simbot.qguild.model.DirectMessageSession
+import love.forte.simbot.qguild.model.Role
 import love.forte.simbot.qguild.stdlib.requestDataBy
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
@@ -95,6 +98,19 @@ internal class QGMemberImpl(
                 sourceGuild = sourceGuild
             ).asCollectable()
 
+    @ExperimentalQGApi
+    override val defaultRoles: List<QGMemberRole>
+        get() = source.roles.mapNotNull { rid ->
+            if (!Role.isDefault(rid)) return@mapNotNull null
+            Role.defaultRole(rid).toGuildRole(
+                bot,
+                guildId,
+                sourceGuild
+            ).toMemberRole(
+                bot,
+                source.user.id.ID
+            )
+        }
 
     @JvmSynthetic
     override suspend fun send(message: Message): QGMessageReceipt {

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/role/QGMemberRoleImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/role/QGMemberRoleImpl.kt
@@ -100,3 +100,4 @@ internal fun QGGuildRoleImpl.toMemberRole(
     guildRole = this,
     memberId = memberId
 )
+

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/role/QGRole.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/role/QGRole.kt
@@ -69,22 +69,26 @@ public interface QGRole : Role, CoroutineScope, QGObjectiveContainer<QGSourceRol
     public val guildId: ID
 
     /**
-     * ARGB的HEX十六进制颜色值转换后的十进制数值
+     * ARGB的HEX十六进制颜色值转换后的十进制数值。
+     * 当不支持获取时（例如当前身份组信息是离线构造出来的默认类型）则可能会得到一个默认值 `0`。
      */
     public val color: Int get() = source.color
 
     /**
      * 是否在成员列表中单独展示。
+     * 当不支持获取时（例如当前身份组信息是离线构造出来的默认类型）则可能会得到一个默认值 `false`。
      */
     public val isHoist: Boolean get() = source.isHoistBool
 
     /**
-     * 人数
+     * 人数。
+     * 当不支持获取时（例如当前身份组信息是离线构造出来的默认类型）则可能会得到一个默认值 `-1`。
      */
     public val number: Int get() = source.number
 
     /**
-     * 成员上限
+     * 成员上限。
+     * 当不支持获取时（例如当前身份组信息是离线构造出来的默认类型）则可能会得到一个默认值 `-1`。
      */
     public val memberLimit: Int get() = source.memberLimit
 


### PR DESCRIPTION
适用场景举例：
想判断发言人是否为管理员，但是没有权限而无法查询roleAPI