### PR TITLE
组件库模块内实现Dms(频道私聊)相关的事件以及bot内的相关送信API

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -56,8 +56,8 @@ object P {
         override val homepage: String get() = HOMEPAGE
 
 
-        const val VERSION = "4.0.0-beta9"
-        const val NEXT_VERSION = "4.0.0-beta10"
+        const val VERSION = "4.0.0-beta10"
+        const val NEXT_VERSION = "4.0.0-beta11"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"
         override val version = if (isSnapshot()) snapshotVersion else VERSION

--- a/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
+++ b/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
@@ -93,6 +93,18 @@ public abstract interface class love/forte/simbot/component/qguild/bot/QGBot : l
 	public synthetic fun me (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract synthetic fun me (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun me$suspendImpl (Llove/forte/simbot/component/qguild/bot/QGBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun sendDmsTo (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun sendDmsTo (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun sendDmsTo (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendDmsToAsync (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendDmsToAsync (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendDmsToAsync (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendDmsToBlocking (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGMessageReceipt;
+	public fun sendDmsToBlocking (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/Message;)Llove/forte/simbot/component/qguild/message/QGMessageReceipt;
+	public fun sendDmsToBlocking (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/component/qguild/message/QGMessageReceipt;
+	public fun sendDmsToReserve (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendDmsToReserve (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendDmsToReserve (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 	public abstract synthetic fun sendTo (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract synthetic fun sendTo (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract synthetic fun sendTo (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -688,6 +700,13 @@ public abstract interface class love/forte/simbot/component/qguild/channel/QGTex
 	public fun sendReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 }
 
+public abstract interface class love/forte/simbot/component/qguild/dms/QGDmsContact : kotlinx/coroutines/CoroutineScope, love/forte/simbot/component/qguild/QGObjectiveContainer, love/forte/simbot/definition/Contact {
+	public fun getAvatar ()Ljava/lang/String;
+	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun getName ()Ljava/lang/String;
+	public abstract fun getSource ()Llove/forte/simbot/qguild/model/User;
+}
+
 public abstract class love/forte/simbot/component/qguild/event/QGAtMessageCreateEvent : love/forte/simbot/component/qguild/event/QGMessageEvent, love/forte/simbot/event/ChatChannelMessageEvent {
 	public fun <init> ()V
 	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -761,7 +780,7 @@ public abstract class love/forte/simbot/component/qguild/event/QGC2CMessageCreat
 	public synthetic fun getContent ()Llove/forte/simbot/definition/Contact;
 	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
-	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
 	public abstract fun getMessageContent ()Llove/forte/simbot/component/qguild/message/QGGroupAndC2CMessageContent;
 	public fun getTime ()Llove/forte/simbot/common/time/Timestamp;
 	public abstract synthetic fun reply (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -843,6 +862,20 @@ public abstract class love/forte/simbot/component/qguild/event/QGChannelUpdateEv
 	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 	public fun getTime ()Llove/forte/simbot/common/time/Timestamp;
 	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/component/qguild/event/QGDirectMessageCreateEvent : love/forte/simbot/component/qguild/event/QGMessageEvent, love/forte/simbot/event/ContactMessageEvent {
+	public fun <init> ()V
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAuthorId ()Llove/forte/simbot/common/id/ID;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/qguild/dms/QGDmsContact;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Contact;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getSourceEventEntity ()Llove/forte/simbot/qguild/model/Message;
+	public fun getTime ()Llove/forte/simbot/common/time/Timestamp;
 }
 
 public abstract class love/forte/simbot/component/qguild/event/QGEvent : love/forte/simbot/event/Event {
@@ -971,7 +1004,7 @@ public abstract class love/forte/simbot/component/qguild/event/QGGroupAtMessageC
 	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
 	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
-	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
 	public abstract fun getMessageContent ()Llove/forte/simbot/component/qguild/message/QGGroupAndC2CMessageContent;
 	public fun getTime ()Llove/forte/simbot/common/time/Timestamp;
 	public abstract synthetic fun reply (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/bot/QGBot.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/bot/QGBot.kt
@@ -28,6 +28,7 @@ import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.qguild.ExperimentalQGApi
 import love.forte.simbot.component.qguild.QQGuildComponent
 import love.forte.simbot.component.qguild.channel.QGTextChannel
+import love.forte.simbot.component.qguild.dms.QGDmsContact
 import love.forte.simbot.component.qguild.event.QGAtMessageCreateEvent
 import love.forte.simbot.component.qguild.event.QGGroupAtMessageCreateEvent
 import love.forte.simbot.component.qguild.friend.QGFriend
@@ -36,6 +37,7 @@ import love.forte.simbot.component.qguild.group.QGGroupRelation
 import love.forte.simbot.component.qguild.guild.QGGuildRelation
 import love.forte.simbot.component.qguild.message.QGMedia
 import love.forte.simbot.component.qguild.message.QGMessageReceipt
+import love.forte.simbot.component.qguild.message.QGReplyTo
 import love.forte.simbot.event.Event
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
@@ -171,6 +173,8 @@ public interface QGBot : Bot, EventMentionAware {
      * —— 因为它跳过了对频道服务器和对子频道类型的校验，失去了在消息中自动填充 `msgId` 等透明行为，并且直接使用ID也会存在一些细微的隐患。
      * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
      *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
+     *
      * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
      * @throws QQGuildApiException 请求异常，例如无权限
      * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
@@ -189,6 +193,8 @@ public interface QGBot : Bot, EventMentionAware {
      * [sendTo] 相对于 [QGTextChannel.send] 而言更加“不可靠”
      * —— 因为它跳过了对频道服务器和对子频道类型的校验，失去了在消息中自动填充 `msgId` 等透明行为，并且直接使用ID也会存在一些细微的隐患。
      * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
+     *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
      *
      * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
      * @throws QQGuildApiException 请求异常，例如无权限
@@ -210,6 +216,8 @@ public interface QGBot : Bot, EventMentionAware {
      * 并且直接使用ID也会存在一些细微的隐患。
      * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
      *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
+     *
      * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
      * @throws QQGuildApiException 请求异常，例如无权限
      * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
@@ -218,6 +226,60 @@ public interface QGBot : Bot, EventMentionAware {
      */
     @ST
     public suspend fun sendTo(channelId: ID, message: MessageContent): QGMessageReceipt
+
+    /**
+     * 直接向目标DMS(频道私聊会话)发送消息。
+     *
+     * [sendDmsTo] 相对于 [QGDmsContact.send] 而言更加“不可靠”
+     * —— 因为它失去了在消息中自动填充 `msgId` 等透明行为，
+     * 且直接使用ID也会存在一些细微的隐患。
+     *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @ST
+    public suspend fun sendDmsTo(id: ID, text: String): QGMessageReceipt
+
+    /**
+     * 直接向目标DMS(频道私聊会话)发送消息。
+     *
+     * [sendDmsTo] 相对于 [QGDmsContact.send] 而言更加“不可靠”
+     * —— 因为它失去了在消息中自动填充 `msgId` 等透明行为，
+     * 且直接使用ID也会存在一些细微的隐患。
+     *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @ST
+    public suspend fun sendDmsTo(id: ID, message: Message): QGMessageReceipt
+
+    /**
+     * 直接向目标DMS(频道私聊会话)发送消息。
+     *
+     * [sendDmsTo] 相对于 [QGDmsContact.send] 而言更加“不可靠”
+     * —— 因为它失去了在消息中自动填充 `msgId` 等透明行为，
+     * 且直接使用ID也会存在一些细微的隐患。
+     *
+     * 如有必要，请不要忘记添加 [QGReplyTo] 来指定一个用于回复标记的 `msgId`。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @ST
+    public suspend fun sendDmsTo(id: ID, message: MessageContent): QGMessageReceipt
 
 
     /**

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/dms/QGDmsContact.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/dms/QGDmsContact.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.dms
+
+import kotlinx.coroutines.CoroutineScope
+import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.StringID.Companion.ID
+import love.forte.simbot.component.qguild.QGObjectiveContainer
+import love.forte.simbot.component.qguild.event.QGDirectMessageCreateEvent
+import love.forte.simbot.definition.Contact
+import love.forte.simbot.qguild.model.User
+
+
+/**
+ * 一个频道中的私聊联系人。
+ * 通过 [QGDirectMessageCreateEvent] 事件得到的内容。
+ *
+ * @author ForteScarlet
+ */
+public interface QGDmsContact : CoroutineScope, Contact, QGObjectiveContainer<User> {
+    override val source: User
+
+    /**
+     * 用户ID
+     */
+    override val id: ID
+        get() = source.id.ID
+
+    /**
+     * 用户名
+     */
+    override val name: String
+        get() = source.username
+
+    /**
+     * 用户头像地址。如果为空则得到 `null`。
+     */
+    override val avatar: String?
+        get() = source.avatar.takeUnless { it.isEmpty() }
+
+
+}

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGC2CMessageCreateEvent.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGC2CMessageCreateEvent.kt
@@ -44,8 +44,7 @@ import love.forte.simbot.suspendrunner.STP
 public abstract class QGC2CMessageCreateEvent : QGBotEvent<C2CMessageCreate>(), ContactMessageEvent {
     abstract override val bot: QGBot
 
-    override val id: ID
-        get() = sourceEventEntity.data.id.ID
+    abstract override val id: ID
 
     @OptIn(ExperimentalQGApi::class)
     override val time: Timestamp

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGDirectMessageCreateEvent.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGDirectMessageCreateEvent.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.event
+
+import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.StringID.Companion.ID
+import love.forte.simbot.common.time.Timestamp
+import love.forte.simbot.component.qguild.ExperimentalQGApi
+import love.forte.simbot.component.qguild.dms.QGDmsContact
+import love.forte.simbot.component.qguild.utils.toTimestamp
+import love.forte.simbot.event.ContactMessageEvent
+import love.forte.simbot.qguild.event.DirectMessageCreate
+import love.forte.simbot.qguild.model.Message
+import love.forte.simbot.suspendrunner.STP
+
+
+/**
+ * 频道单聊事件，源自 [DirectMessageCreate]
+ *
+ * @see DirectMessageCreate
+ * @author ForteScarlet
+ */
+public abstract class QGDirectMessageCreateEvent : QGMessageEvent(), ContactMessageEvent {
+    abstract override val sourceEventEntity: Message
+
+    @OptIn(ExperimentalQGApi::class)
+    override val time: Timestamp
+        get() = sourceEventEntity.timestamp.toTimestamp()
+
+    override val authorId: ID
+        get() = sourceEventEntity.author.id.ID
+
+    /**
+     * 发送消息的频道私聊用户目标
+     */
+    @STP
+    abstract override suspend fun content(): QGDmsContact
+
+
+}

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGGroupAtMessageCreateEvent.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/event/QGGroupAtMessageCreateEvent.kt
@@ -48,8 +48,7 @@ public abstract class QGGroupAtMessageCreateEvent : QGBotEvent<GroupAtMessageCre
     /**
      * 事件ID
      */
-    override val id: ID
-        get() = sourceEventEntity.data.id.ID
+    abstract override val id: ID
 
     /**
      * 事件时间

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGBotImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGBotImpl.kt
@@ -49,6 +49,7 @@ import love.forte.simbot.component.qguild.internal.role.toGuildRole
 import love.forte.simbot.component.qguild.internal.role.toMemberRole
 import love.forte.simbot.component.qguild.message.QGMedia
 import love.forte.simbot.component.qguild.message.QGMessageReceipt
+import love.forte.simbot.component.qguild.message.sendDmsMessage
 import love.forte.simbot.component.qguild.message.sendMessage
 import love.forte.simbot.event.EventDispatcher
 import love.forte.simbot.event.onEachError
@@ -318,6 +319,30 @@ internal class QGBotImpl(
             sendMessage(channelId.literal, message)
         } catch (e: QQGuildApiException) {
             throw e.addStackTrace { "Bot.sendTo" }
+        }
+    }
+
+    override suspend fun sendDmsTo(id: ID, text: String): QGMessageReceipt {
+        return try {
+            sendDmsMessage(id.literal, text)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendDmsTo" }
+        }
+    }
+
+    override suspend fun sendDmsTo(id: ID, message: Message): QGMessageReceipt {
+        return try {
+            sendDmsMessage(id.literal, message)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendDmsTo" }
+        }
+    }
+
+    override suspend fun sendDmsTo(id: ID, message: MessageContent): QGMessageReceipt {
+        return try {
+            sendDmsMessage(id.literal, message)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendDmsTo" }
         }
     }
 

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGEventProcess.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/bot/QGEventProcess.kt
@@ -146,15 +146,19 @@ internal fun QGBotImpl.registerEventProcessor(): DisposableHandle {
             // 消息
             /// 频道
             is AtMessageCreate -> {
-                pushEvent { QGAtMessageCreateEventImpl(bot, raw, event.data) }
+                pushEvent { QGAtMessageCreateEventImpl(bot, raw, event.data, event.id) }
+            }
+            /// 频道单聊
+            is DirectMessageCreate -> {
+                pushEvent { QGDirectMessageCreateEventImpl(bot, raw, event.data, event.id) }
             }
             /// 群&单聊
             is GroupAtMessageCreate -> {
-                pushEvent { QGGroupAtMessageCreateEventImpl(bot, raw, event) }
+                pushEvent { QGGroupAtMessageCreateEventImpl(bot, raw, event, event.id) }
             }
 
             is C2CMessageCreate -> {
-                pushEvent { QGC2CMessageCreateEventImpl(bot, raw, event) }
+                pushEvent { QGC2CMessageCreateEventImpl(bot, raw, event, event.id) }
             }
 
             // 群聊：managements

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/dms/QGDmsContactImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/dms/QGDmsContactImpl.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.qguild.internal.dms
+
+import love.forte.simbot.component.qguild.dms.QGDmsContact
+import love.forte.simbot.component.qguild.internal.bot.QGBotImpl
+import love.forte.simbot.component.qguild.internal.bot.newSupervisorCoroutineContext
+import love.forte.simbot.component.qguild.message.sendDmsMessage
+import love.forte.simbot.component.qguild.message.sendMessage
+import love.forte.simbot.message.Message
+import love.forte.simbot.message.MessageContent
+import love.forte.simbot.message.MessageReceipt
+import love.forte.simbot.qguild.QQGuildApiException
+import love.forte.simbot.qguild.addStackTrace
+import love.forte.simbot.qguild.model.User
+import kotlin.coroutines.CoroutineContext
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+internal class QGDmsContactImpl(
+    private val bot: QGBotImpl,
+    override val source: User,
+    private val guildId: String,
+    private val currentMsgId: String?,
+) : QGDmsContact {
+    override val coroutineContext: CoroutineContext = bot.newSupervisorCoroutineContext()
+
+    override suspend fun send(text: String): MessageReceipt {
+        return try {
+            bot.sendDmsMessage(guildId, text) {
+                if (msgId == null) {
+                    msgId = currentMsgId
+                }
+            }
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "dmsContact.send" }
+        }
+    }
+
+    override suspend fun send(message: Message): MessageReceipt {
+        return try {
+            bot.sendDmsMessage(guildId, message) {
+                if (msgId == null) {
+                    msgId = currentMsgId
+                }
+            }
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "dmsContact.send" }
+        }
+    }
+
+    override suspend fun send(messageContent: MessageContent): MessageReceipt {
+        return try {
+            bot.sendMessage(source.id, messageContent) {
+                if (msgId == null) {
+                    msgId = currentMsgId
+                }
+            }
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "dmsContact.send" }
+        }
+    }
+
+    override fun toString(): String {
+        return "QGDmsContact(id=$id, name=$name, source=$source)"
+    }
+}
+
+internal fun User.toDmsContact(
+    bot: QGBotImpl,
+    guildId: String,
+    currentMsgId: String? = null,
+): QGDmsContactImpl = QGDmsContactImpl(
+    bot = bot,
+    source = this,
+    guildId = guildId,
+    currentMsgId = currentMsgId
+)

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/event/QGC2CMessageCreateEventImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/event/QGC2CMessageCreateEventImpl.kt
@@ -19,6 +19,7 @@ package love.forte.simbot.component.qguild.internal.event
 
 import love.forte.simbot.common.atomic.AtomicInt
 import love.forte.simbot.common.atomic.atomic
+import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.qguild.event.QGC2CMessageCreateEvent
 import love.forte.simbot.component.qguild.friend.QGFriend
@@ -43,8 +44,12 @@ internal class QGC2CMessageCreateEventImpl(
     override val bot: QGBotImpl,
     override val sourceEventRaw: String,
     override val sourceEventEntity: C2CMessageCreate,
+    private val eventId: String?,
     private val msgSeq: AtomicInt = atomic(1)
 ) : QGC2CMessageCreateEvent() {
+    override val id: ID
+        get() = eventId?.ID ?: sourceEventEntity.data.id.ID
+
     override val messageContent: QGGroupAndC2CMessageContent =
         QGGroupAndC2CMessageContentImpl(
             sourceEventEntity.data.id.ID,

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/event/QGGroupAtMessageCreateEventImpl.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/internal/event/QGGroupAtMessageCreateEventImpl.kt
@@ -19,6 +19,7 @@ package love.forte.simbot.component.qguild.internal.event
 
 import love.forte.simbot.common.atomic.AtomicInt
 import love.forte.simbot.common.atomic.atomic
+import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.qguild.event.QGGroupAtMessageCreateEvent
 import love.forte.simbot.component.qguild.group.QGGroup
@@ -45,8 +46,12 @@ internal class QGGroupAtMessageCreateEventImpl(
     override val bot: QGBotImpl,
     override val sourceEventRaw: String,
     override val sourceEventEntity: GroupAtMessageCreate,
-    private val msgSeq: AtomicInt = atomic(1)
+    private val eventId: String?,
+    private val msgSeq: AtomicInt = atomic(1),
 ) : QGGroupAtMessageCreateEvent() {
+    override val id: ID
+        get() = eventId?.ID ?: sourceEventEntity.data.id.ID
+
     override suspend fun author(): QGGroupMember {
         return QGGroupMemberImpl(
             bot,


### PR DESCRIPTION
新增事件 `QGDirectMessageCreateEvent` 实现；
新增类型 `QGDmsContact` 实现，可从上述事件内获取；
`QGBot` 中新增三个重载API：`sendDmsTo` 用于直接向指定DMS发送消息。