### PR TITLE
fix: 修复 ed25519 验签参数错误问题

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -56,7 +56,7 @@ object P {
         override val homepage: String get() = HOMEPAGE
 
 
-        const val VERSION = "4.1.1"
+        const val VERSION = "4.1.2"
         const val NEXT_VERSION = "4.1.2"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"

--- a/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/internal/BotImpl.kt
+++ b/simbot-component-qq-guild-stdlib/src/commonMain/kotlin/love/forte/simbot/qguild/stdlib/internal/BotImpl.kt
@@ -443,7 +443,7 @@ internal class BotImpl(
 
             val msg = "$signatureTimestamp$payload"
 
-            check(ed25519PublicKey.verify(msg.toByteArray(), signatureBytes)) {
+            check(ed25519PublicKey.verify(signature = signatureBytes, message = msg.toByteArray())) {
                 "Ed25519 verify failed"
             }
         }


### PR DESCRIPTION
之前 `msg` 和 `sig` 参数反了，会导致验签**必然失败**。

> [!warning]
> 目前使用的 ed25519 库 [kotlin-multiplatform-libsodium](https://github.com/ionspin/kotlin-multiplatform-libsodium)
> 
> 也并不好用，JVM下如果直接使用 fat jar 可能会出现无法加载原生库的问题。