### PR TITLE
修复 Markdown 消息中 `params` 参数格式错误的问题

### DIFF
--- a/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
+++ b/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
@@ -5426,23 +5426,27 @@ public final class love/forte/simbot/qguild/model/Message$Embed$Thumbnail$Compan
 public final class love/forte/simbot/qguild/model/Message$Markdown {
 	public static final field Companion Llove/forte/simbot/qguild/model/Message$Markdown$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Llove/forte/simbot/qguild/model/Message$Markdown$Params;
+	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
-	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/Message$Markdown;Ljava/lang/Integer;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/Message$Markdown;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun createByContent (Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun createByCustomTemplateId (Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static final fun createByCustomTemplateId (Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun createByTemplateId (I)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static final fun createByTemplateId (ILjava/util/List;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Ljava/lang/String;
 	public final fun getCustomTemplateId ()Ljava/lang/String;
-	public final fun getParams ()Llove/forte/simbot/qguild/model/Message$Markdown$Params;
+	public final fun getParams ()Ljava/util/List;
 	public final fun getTemplateId ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5462,11 +5466,48 @@ public synthetic class love/forte/simbot/qguild/model/Message$Markdown$$serializ
 public final class love/forte/simbot/qguild/model/Message$Markdown$Companion {
 	public final fun createByContent (Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public final fun createByCustomTemplateId (Ljava/lang/String;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun createByCustomTemplateId (Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public final fun createByTemplateId (I)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun createByTemplateId (ILjava/util/List;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;ILjava/util/List;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;ILlove/forte/simbot/qguild/model/Message$Markdown$Param;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/qguild/model/Message$Markdown$Companion;ILlove/forte/simbot/qguild/model/Message$Markdown$Params;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/Message$Markdown$Param {
+	public static final field Companion Llove/forte/simbot/qguild/model/Message$Markdown$Param$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/qguild/model/Message$Markdown$Param;
+	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/Message$Markdown$Param;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/Message$Markdown$Param;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/qguild/model/Message$Markdown$Param$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/qguild/model/Message$Markdown$Param$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/qguild/model/Message$Markdown$Param;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/qguild/model/Message$Markdown$Param;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/Message$Markdown$Param$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
+++ b/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
@@ -1828,8 +1828,12 @@ public final class love/forte/simbot/component/qguild/message/QGMarkdown : love/
 	public final fun component1 ()Llove/forte/simbot/qguild/model/Message$Markdown;
 	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static final fun createByCustomTemplateId (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static final fun createByCustomTemplateId (Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static final fun createByTemplateId (I)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static final fun createByTemplateId (ILjava/util/List;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMarkdown ()Llove/forte/simbot/qguild/model/Message$Markdown;
@@ -1852,10 +1856,18 @@ public final class love/forte/simbot/component/qguild/message/QGMarkdown$Compani
 	public final fun byMarkdown (Llove/forte/simbot/qguild/model/Message$Markdown;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun createByCustomTemplateId (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public final fun createByCustomTemplateId (Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun createByCustomTemplateId (Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Param;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static synthetic fun createByCustomTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;Ljava/lang/String;Llove/forte/simbot/qguild/model/Message$Markdown$Params;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun createByTemplateId (I)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public final fun createByTemplateId (ILjava/util/List;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Param;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun createByTemplateId (ILlove/forte/simbot/qguild/model/Message$Markdown$Params;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;ILjava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
+	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;ILlove/forte/simbot/qguild/model/Message$Markdown$Param;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public static synthetic fun createByTemplateId$default (Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;ILlove/forte/simbot/qguild/model/Message$Markdown$Params;ILjava/lang/Object;)Llove/forte/simbot/component/qguild/message/QGMarkdown;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGMarkdown.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGMarkdown.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2025. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -21,6 +21,7 @@ import kotlinx.serialization.Serializable
 import love.forte.simbot.message.Messages
 import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
 import love.forte.simbot.qguild.model.Message
+import love.forte.simbot.qguild.model.Message.Markdown.Param
 import love.forte.simbot.qguild.model.Message.Markdown.Params
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
@@ -41,14 +42,14 @@ public data class QGMarkdown internal constructor(
          * 使用 [markdown] 直接包装构建。
          */
         @JvmStatic
-        public fun byMarkdown(markdown: Message.Markdown) : QGMarkdown =
+        public fun byMarkdown(markdown: Message.Markdown): QGMarkdown =
             QGMarkdown(markdown)
 
         /**
          * 使用 [content] 构建一个 [QGMarkdown]。
          */
         @JvmStatic
-        public fun create(content: String) : QGMarkdown =
+        public fun create(content: String): QGMarkdown =
             byMarkdown(Message.Markdown(content = content))
 
         /**
@@ -57,8 +58,34 @@ public data class QGMarkdown internal constructor(
          * @see Message.Markdown.createByTemplateId
          */
         @JvmStatic
+        @Deprecated(
+            "Use createByTemplateId(templateId, Param(...))",
+            replaceWith = ReplaceWith(
+                "createByTemplateId(templateId, params?.let { Param(it.key, it.values) })",
+                "love.forte.simbot.qguild.model.Message.Markdown.Param"
+            )
+        )
+        @Suppress("DEPRECATION")
+        public fun createByTemplateId(templateId: Int, params: Params? = null): QGMarkdown =
+            createByTemplateId(templateId, params?.let { Param(it.key, it.values) })
+
+        /**
+         * 使用 `templateId` 构建一个 [QGMarkdown]。
+         *
+         * @see Message.Markdown.createByTemplateId
+         */
+        @JvmStatic
         @JvmOverloads
-        public fun createByTemplateId(templateId: Int, params: Params? = null) : QGMarkdown =
+        public fun createByTemplateId(templateId: Int, param: Param? = null): QGMarkdown =
+            byMarkdown(Message.Markdown.createByTemplateId(templateId, param?.let { listOf(it) }))
+
+        /**
+         * 使用 `templateId` 构建一个 [QGMarkdown]。
+         *
+         * @see Message.Markdown.createByTemplateId
+         */
+        @JvmStatic
+        public fun createByTemplateId(templateId: Int, params: List<Param>? = null): QGMarkdown =
             byMarkdown(Message.Markdown.createByTemplateId(templateId, params))
 
         /**
@@ -67,8 +94,41 @@ public data class QGMarkdown internal constructor(
          * @see Message.Markdown.createByCustomTemplateId
          */
         @JvmStatic
+        @Deprecated(
+            "Use createByCustomTemplateId(customTemplateId, Param(...))",
+            replaceWith = ReplaceWith(
+                "createByCustomTemplateId(customTemplateId, " +
+                        "params?.let { Param(it.key, it.values) })",
+                "love.forte.simbot.qguild.model.Message.Markdown.Param"
+            )
+        )
+        @Suppress("DEPRECATION")
+        public fun createByCustomTemplateId(customTemplateId: String, params: Params? = null): QGMarkdown =
+            createByCustomTemplateId(
+                customTemplateId,
+                param = params?.let { Param(it.key, it.values) }
+            )
+
+        /**
+         * 使用 `customTemplateId` 构建一个 [QGMarkdown]。
+         *
+         * @see Message.Markdown.createByCustomTemplateId
+         */
+        @JvmStatic
         @JvmOverloads
-        public fun createByCustomTemplateId(customTemplateId: String, params: Params? = null) : QGMarkdown =
+        public fun createByCustomTemplateId(customTemplateId: String, param: Param? = null): QGMarkdown =
+            byMarkdown(Message.Markdown.createByCustomTemplateId(
+                customTemplateId,
+                param?.let { listOf(it) }
+            ))
+
+        /**
+         * 使用 `customTemplateId` 构建一个 [QGMarkdown]。
+         *
+         * @see Message.Markdown.createByCustomTemplateId
+         */
+        @JvmStatic
+        public fun createByCustomTemplateId(customTemplateId: String, params: List<Param>? = null): QGMarkdown =
             byMarkdown(Message.Markdown.createByCustomTemplateId(customTemplateId, params))
     }
 }


### PR DESCRIPTION
将 `Message.Markdown.params` 的格式由 `Params?` 修改为 `List<Param>?`

此修改二进制和源码不兼容，但是如果你按照推荐操作使用 `Markdown` 的工厂函数构建它，那么工厂函数提供了兼容平滑的废弃迁移方案，是兼容的。

例如：

```Kotlin
Message.Markdown.createByCustomTemplateId("123456_654321", Params("key", listOf("values")))
```

此处会有废弃警告和替换推荐。